### PR TITLE
Allow EG Token to be passed to constructor

### DIFF
--- a/lib/deleteFunction.js
+++ b/lib/deleteFunction.js
@@ -5,7 +5,7 @@ const headersUtils = require('./utils/headers')
 
 module.exports = (config, params) => {
   const path = `/v1/spaces/${config.space}/functions/${params.functionId}`
-  const headers = headersUtils.injectToken({})
+  const headers = headersUtils.injectToken({}, config.token)
 
   return config
     .fetch(urlUtils.joinUrlWithPath(config.configurationUrl, path), {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ class EventGateway {
       // eslint-disable-next-line global-require
       fetch: configuration.fetch || require('isomorphic-fetch'),
       space: configuration.space || 'default',
+      token: configuration.token || '',
     }
 
     return {

--- a/lib/listFunctions.js
+++ b/lib/listFunctions.js
@@ -8,7 +8,7 @@ module.exports = config => {
 
   return config
     .fetch(urlUtils.joinUrlWithPath(config.configurationUrl, path), {
-      headers: headersUtils.injectToken({}),
+      headers: headersUtils.injectToken({}, config.token),
     })
     .then(response => {
       if (response.status !== 200) {

--- a/lib/listSubscriptions.js
+++ b/lib/listSubscriptions.js
@@ -8,7 +8,7 @@ module.exports = config => {
 
   return config
     .fetch(urlUtils.joinUrlWithPath(config.configurationUrl, path), {
-      headers: headersUtils.injectToken({}),
+      headers: headersUtils.injectToken({}, config.token),
     })
     .then(response => {
       if (response.status !== 200) {

--- a/lib/registerFunction.js
+++ b/lib/registerFunction.js
@@ -5,7 +5,7 @@ const headersUtils = require('./utils/headers')
 
 module.exports = (config, params) => {
   const path = `/v1/spaces/${config.space}/functions`
-  const headers = headersUtils.injectToken({ 'Content-Type': 'application/json' })
+  const headers = headersUtils.injectToken({ 'Content-Type': 'application/json' }, config.token)
 
   return config
     .fetch(urlUtils.joinUrlWithPath(config.configurationUrl, path), {

--- a/lib/subscribe.js
+++ b/lib/subscribe.js
@@ -10,7 +10,7 @@ module.exports = (config, params) => {
     .fetch(urlUtils.joinUrlWithPath(config.configurationUrl, path), {
       method: 'POST',
       body: JSON.stringify(params),
-      headers: headersUtils.injectToken({ 'Content-Type': 'application/json' }),
+      headers: headersUtils.injectToken({ 'Content-Type': 'application/json' }, config.token),
     })
     .then(response => {
       if (response.status !== 201) {

--- a/lib/unsubscribe.js
+++ b/lib/unsubscribe.js
@@ -9,7 +9,7 @@ module.exports = (config, params) => {
   return config
     .fetch(urlUtils.joinUrlWithPath(config.configurationUrl, path), {
       method: 'DELETE',
-      headers: headersUtils.injectToken({}),
+      headers: headersUtils.injectToken({}, config.token),
     })
     .then(response => {
       if (response.status !== 204) {

--- a/lib/utils/headers.js
+++ b/lib/utils/headers.js
@@ -5,11 +5,14 @@ const contains = require('ramda/src/contains')
 const assoc = require('ramda/src/assoc')
 
 module.exports = {
-  injectToken: headers => {
+  injectToken: (headers, token) => {
     let updatedHeaders = Object.assign({}, headers)
-    const isTokenIncluded = contains('EVENT_GATEWAY_TOKEN', keys(process.env))
-    if (isTokenIncluded) {
-      updatedHeaders = assoc('Authorization', `bearer ${process.env.EVENT_GATEWAY_TOKEN}`, headers)
+    let authToken = token || ''
+    if (authToken === '' && contains('EVENT_GATEWAY_TOKEN', keys(process.env))) {
+      authToken = process.env.EVENT_GATEWAY_TOKEN
+    }
+    if (authToken !== '') {
+      updatedHeaders = assoc('Authorization', `bearer ${authToken}`, headers)
     }
     return updatedHeaders
   },

--- a/tests/utils.headers.injectToken.test.js
+++ b/tests/utils.headers.injectToken.test.js
@@ -4,14 +4,37 @@ afterEach(() => {
   delete process.env.EVENT_GATEWAY_TOKEN
 })
 
-test('should inject the Authorization header if serverless application token is present', () => {
+test('should inject the Authorization header if a token is provided', () => {
+  const token = 'hjkl-5678'
+  const headers = {
+    'Content-Type': 'application/json',
+  }
+  expect(headersUtils.injectToken(headers, token)).toEqual({
+    'Content-Type': 'application/json',
+    Authorization: 'bearer hjkl-5678',
+  })
+})
+
+test('should inject the Authorization header if serverless application token is present as env variable', () => {
   process.env.EVENT_GATEWAY_TOKEN = 'wasd-1234'
   const headers = {
     'Content-Type': 'application/json',
   }
-  expect(headersUtils.injectToken(headers)).toEqual({
+  expect(headersUtils.injectToken(headers, '')).toEqual({
     'Content-Type': 'application/json',
     Authorization: 'bearer wasd-1234',
+  })
+})
+
+test('should prefer a given token over the environment variable for Authorization header if both are present', () => {
+  process.env.EVENT_GATEWAY_TOKEN = 'wasd-1234'
+  const token = 'hjkl-5678'
+  const headers = {
+    'Content-Type': 'application/json',
+  }
+  expect(headersUtils.injectToken(headers, token)).toEqual({
+    'Content-Type': 'application/json',
+    Authorization: 'bearer hjkl-5678',
   })
 })
 
@@ -19,7 +42,7 @@ test('should return the same headers if serverless application token is NOT pres
   const headers = {
     'Content-Type': 'application/json',
   }
-  expect(headersUtils.injectToken(headers)).toEqual({
+  expect(headersUtils.injectToken(headers, '')).toEqual({
     'Content-Type': 'application/json',
   })
 })


### PR DESCRIPTION
Add ability to pass the EG token to the constructor rather than only pulling from environment variable:

```javascript
const SDK = require('@serverless/event-gateway-sdk');
const eventGateway = new SDK({
  url: 'http://localhost' ,
  token: 'asdf-1234',
})
```

If client has a token and the `EVENT_GATEWAY_TOKEN` is present in env variable, the client token takes precedence. 