### PR TITLE
Add UpdateFunction method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ JavaScript library for interacting with the [Event Gateway](https://github.com/s
   - [Constructor](#constructor)
   - [List Functions](#list-functions)
   - [Register Function](#register-function)
+  - [Update Function](#update-function)
   - [Delete Function](#delete-function)
   - [List Subscriptions](#list-subscriptions)
   - [Subscribe](#subscribe)
@@ -117,6 +118,7 @@ eventGateway.listFunctions()
 Object:
 
 - `functionId` - `string` - function ID
+- `type` - `string` - Type of function provider
 - `provider` - `object` - provider spec
 
 For more details see Event Gateway [Register Functions docs](https://github.com/serverless/event-gateway#register-function).
@@ -128,8 +130,35 @@ Promise object resolving to Function object
 ```js
 eventGateway.registerFunction({
   functionId: 'sendEmail',
+  type:'awslambda',
   provider: {
-    type:'awslambda',
+    arn: 'xxx',
+    region: 'us-west-2',
+  }
+})
+```
+
+#### Update Function
+
+**Parameters**
+
+Object:
+
+- `functionId` - `string` - function ID
+- `type` - `string` - Type of function provider
+- `provider` - `object` - provider spec
+
+For more details see Event Gateway [Update Functions docs](https://github.com/serverless/event-gateway#update-function).
+
+**Returns**
+
+Promise object resolving to Function object
+
+```js
+eventGateway.updateFunction({
+  functionId: 'sendEmail',
+  type:'awslambda',
+  provider: {
     arn: 'xxx',
     region: 'us-west-2',
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const isNil = require('ramda/src/isNil')
 const emit = require('./emit')
 const invoke = require('./invoke')
 const registerFunction = require('./registerFunction')
+const updateFunction = require('./updateFunction')
 const deleteFunction = require('./deleteFunction')
 const listFunctions = require('./listFunctions')
 const subscribe = require('./subscribe')
@@ -35,6 +36,7 @@ class EventGateway {
       emit: params => emit(config, params),
       invoke: params => invoke(config, params),
       registerFunction: params => registerFunction(config, params),
+      updateFunction: params => updateFunction(config, params),
       deleteFunction: params => deleteFunction(config, params),
       listFunctions: () => listFunctions(config),
       subscribe: params => subscribe(config, params),

--- a/lib/updateFunction.js
+++ b/lib/updateFunction.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const urlUtils = require('./utils/url')
+const headersUtils = require('./utils/headers')
+
+module.exports = (config, params) => {
+  const path = `/v1/spaces/${config.space}/functions/${params.functionId}`
+  const headers = headersUtils.injectKey({ 'Content-Type': 'application/json' }, config.apiKey)
+
+  return config
+    .fetch(urlUtils.joinUrlWithPath(config.configurationUrl, path), {
+      method: 'PUT',
+      body: JSON.stringify(params),
+      headers
+    })
+    .then(response => {
+      if (response.status !== 200) {
+        let errorMessage = null
+        const funcId = params.functionId
+        return response
+          .json()
+          .then(res => {
+            errorMessage = res.errors[0].message
+            throw new Error(`Internal rethrow of ${errorMessage}`)
+          })
+          .catch(() => {
+            if (errorMessage) {
+              throw new Error(`Failed to update the function ${funcId} due the error: ${errorMessage}`)
+            } else {
+              throw new Error(`Failed to update the function ${funcId} and couldn't parse error body.`)
+            }
+          })
+      }
+      return response.json()
+    })
+}

--- a/tests/__snapshots__/manage-functions.test.js.snap
+++ b/tests/__snapshots__/manage-functions.test.js.snap
@@ -2,4 +2,6 @@
 
 exports[`should fail to re-add the same function 1`] = `[Error: Failed to register the function hello due the error: Function "hello" already registered.]`;
 
-exports[`should fail to remove a none-existing function 1`] = `[Error: Failed to delete the function missing-func due the error: Function "missing-func" not found.]`;
+exports[`should fail to remove a non-existing function 1`] = `[Error: Failed to delete the function missing-func due the error: Function "missing-func" not found.]`;
+
+exports[`should fail to update a non-existing function 1`] = `[Error: Failed to update the function hello due the error: Function "hello" not found.]`;

--- a/tests/manage-functions.test.js
+++ b/tests/manage-functions.test.js
@@ -10,6 +10,15 @@ const functionConfig = {
     region: 'us-east-1'
   }
 }
+const updatedConfig = {
+  space: 'testspace',
+  functionId: 'hello',
+  provider: {
+    type: 'awslambda',
+    arn: 'arn::::',
+    region: 'us-west-1'
+  }
+}
 let eventGateway
 let eventGatewayProcessId
 
@@ -47,6 +56,13 @@ test('should fail to re-add the same function', () => {
   })
 })
 
+test('should update an existing function', () => {
+  expect.assertions(1)
+  return eventGateway.updateFunction(updatedConfig).then(response => {
+    expect(response).toEqual(updatedConfig)
+  })
+})
+
 test('should remove the added function', () => {
   expect.assertions(1)
   return eventGateway.deleteFunction({ functionId: 'hello' }).then(response => {
@@ -54,9 +70,16 @@ test('should remove the added function', () => {
   })
 })
 
-test('should fail to remove a none-existing function', () => {
+test('should fail to remove a non-existing function', () => {
   expect.assertions(1)
   return eventGateway.deleteFunction({ functionId: 'missing-func' }).catch(err => {
+    expect(err).toMatchSnapshot()
+  })
+})
+
+test('should fail to update a non-existing function', () => {
+  expect.assertions(1)
+  return eventGateway.updateFunction(updatedConfig).catch(err => {
     expect(err).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Add the `updateFunction()` method to the EG client.

Also, it updates the documentation for `registerFunction` to move `type` outside of the `provider` object.