### PR TITLE
Remove ramda dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const isNil = require('ramda/src/isNil')
 const fetch = require('isomorphic-fetch')
 const emit = require('./emit')
 const invoke = require('./invoke')
@@ -16,9 +15,9 @@ const UrlParse = require('url-parse')
 class EventGateway {
   constructor (configuration) {
     if (
-      isNil(configuration) ||
+      configuration == null ||
       typeof configuration !== 'object' ||
-      isNil(configuration.url) ||
+      configuration.url == null ||
       typeof configuration.url !== 'string'
     ) {
       throw new Error('Required "url" property is missing from Event Gateway configuration')

--- a/lib/utils/headers.js
+++ b/lib/utils/headers.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const assoc = require('ramda/src/assoc')
-
 module.exports = {
   injectKey: (headers, key) => {
     let updatedHeaders = Object.assign({}, headers)
     const accessKey = key || process.env.EVENT_GATEWAY_ACCESS_KEY
     if (accessKey) {
-      updatedHeaders = assoc('Authorization', `bearer ${accessKey}`, headers)
+      updatedHeaders['Authorization'] = `bearer ${accessKey}`
     }
     return updatedHeaders
   }

--- a/lib/utils/url.js
+++ b/lib/utils/url.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const last = require('ramda/src/last')
-
 module.exports = {
   joinUrlWithPath: (baseUrl, path) => {
-    const urlHasSlash = last(baseUrl) === '/'
+    const urlHasSlash = baseUrl.slice(-1) === '/'
     const pathHasSlash = path[0] === '/'
     if (urlHasSlash && pathHasSlash) {
       return `${baseUrl}${path.substring(1)}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4013,11 +4013,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
       "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
     },
-    "ramda": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-      "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc="
-    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
-    "ramda": "^0.24.1",
     "url-parse": "^1.1.9"
   },
   "devDependencies": {


### PR DESCRIPTION
We aren't actually using Ramda features in SDK. It only increases the SDK size without any benefits.