### PR TITLE
[WIP] Add options to emit() method

### DIFF
--- a/lib/emit.js
+++ b/lib/emit.js
@@ -1,13 +1,22 @@
 'use strict'
 
-module.exports = (config, event) => {
+module.exports = (config, event, options) => {
+  let path = '/'
+  let headers = {
+    'Content-Type': 'application/cloudevents+json'
+  }
+  if (options) {
+    path = options.path || path
+    if (!path.startsWith('/')) {
+      path = '/' + path
+    }
+    headers = Object.assign(headers, options.headers)
+  }
   return config
-    .fetch(`${config.eventsUrl}`, {
+    .fetch(`${config.eventsUrl}${path}`, {
       method: 'POST',
       body: JSON.stringify(event),
-      headers: {
-        'Content-Type': 'application/cloudevents+json'
-      }
+      headers
     })
     .then(response => {
       if (response.status >= 400) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,8 +37,8 @@ class EventGateway {
     this.config = config
   }
 
-  emit (params) {
-    return emit(this.config, params)
+  emit (event, options) {
+    return emit(this.config, event, options)
   }
 
   createEventType (params) {


### PR DESCRIPTION
Closes #52.

Adds an optional `options` parameter in the `emit()` method for setting path or headers in the request.

Example usage:

```js
eventGateway.emit({
  eventID: '1',
  eventType: 'user.created',
  cloudEventsVersion: '0.1',
  source: '/services/users',
  contentType: 'application/json',
  data: {
    userID: 'foo'
  }}, {
  path: /users,
  headers: {
    "Authorization": "Bearer 1234"
  }
})
```

I'm having trouble getting the existing tests to run on my machine due to port contention issues. Seeing if they'll run in Travis.